### PR TITLE
check and use ~/.gdrive/credentials.json

### DIFF
--- a/handlers_drive.go
+++ b/handlers_drive.go
@@ -9,13 +9,16 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/oauth2/google"
+	gd "google.golang.org/api/drive/v3"
+
 	"github.com/prasmussen/gdrive/auth"
 	"github.com/prasmussen/gdrive/cli"
 	"github.com/prasmussen/gdrive/drive"
 )
 
-const ClientId = "367116221053-7n0vf5akeru7on6o2fjinrecpdoe99eg.apps.googleusercontent.com"
-const ClientSecret = "1qsNodXNaWq1mQuBjUjmvhoO"
+var ClientId = "367116221053-7n0vf5akeru7on6o2fjinrecpdoe99eg.apps.googleusercontent.com"
+var ClientSecret = "1qsNodXNaWq1mQuBjUjmvhoO"
 const TokenFilename = "token_v2.json"
 const DefaultCacheFileName = "file_cache.json"
 
@@ -341,6 +344,26 @@ func aboutExportHandler(ctx cli.Context) {
 }
 
 func getOauthClient(args cli.Arguments) (*http.Client, error) {
+	configDir := getConfigDir(args)
+
+	// IF there exists .gdrive/credentials.json, use it.
+	// Otherwise fall back to our default hardcoded project
+	b, err := ioutil.ReadFile(ConfigFilePath(configDir, "credentials.json"))
+	if err == nil {
+		gconfig,err := google.ConfigFromJSON(b, gd.DriveMetadataReadonlyScope)
+
+		// If above is present, ideally we could just use
+		// gconfig.Client(context.Background(), token
+		// see https://developers.google.com/drive/api/v3/quickstart/go
+		// but that will have to be in future version of the code
+        	if err == nil {
+			ClientId = gconfig.ClientID
+			ClientSecret = gconfig.ClientSecret
+		}
+		
+	}
+
+
 	if args.String("refreshToken") != "" && args.String("accessToken") != "" {
 		ExitF("Access token not needed when refresh token is provided")
 	}
@@ -353,7 +376,6 @@ func getOauthClient(args cli.Arguments) (*http.Client, error) {
 		return auth.NewAccessTokenClient(ClientId, ClientSecret, args.String("accessToken")), nil
 	}
 
-	configDir := getConfigDir(args)
 
 	if args.String("serviceAccount") != "" {
 		serviceAccountPath := ConfigFilePath(configDir, args.String("serviceAccount"))
@@ -365,6 +387,8 @@ func getOauthClient(args cli.Arguments) (*http.Client, error) {
 	}
 
 	tokenPath := ConfigFilePath(configDir, TokenFilename)
+
+	println("Debug: using clientid=\n", ClientId);
 	return auth.NewFileSourceClient(ClientId, ClientSecret, tokenPath, authCodePrompt)
 }
 


### PR DESCRIPTION
I tested this and it seems to work.

If a user has created their own project, and generated creds for it, and downloaded credentials.json ...
they can save it in ~/.gdrive/credentials.json, and gdrive will now open it and use the clientid and secret from it.

